### PR TITLE
Add files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,124 @@
+---
+Language: Cpp
+BasedOnStyle: LLVM
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: Left
+AlignConsecutiveAssignments: AcrossComments
+AlignConsecutiveBitFields: AcrossComments
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: AcrossComments
+AlignEscapedNewlines: Right
+AlignOperands: Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: No
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: None
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterStruct: false
+  AfterUnion: false
+  AfterExternBlock: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Linux
+BreakBeforeTernaryOperators: false
+BreakStringLiterals: true
+ColumnLimit: 80
+CommentPragmas: "^ IWYU pragma:"
+ContinuationIndentWidth: 4
+DeriveLineEnding: true
+DerivePointerAlignment: true
+DisableFormat: false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority: 2
+    SortPriority: 0
+  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
+    Priority: 3
+    SortPriority: 0
+  - Regex: ".*"
+    Priority: 1
+    SortPriority: 0
+IncludeIsMainRegex: "(Test)?$"
+IncludeIsMainSourceRegex: ""
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: NoIndent
+IndentGotoLabels: false
+IndentPPDirectives: AfterHash
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ""
+MacroBlockEnd: ""
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+PPIndentWidth: 1
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+# QualifierAlignment Leave
+# QualifierOrder []
+ReflowComments: true
+SortIncludes: CaseSensitive
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Latest
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth: 8
+UseCRLF: false
+UseTab: Never
+WhitespaceSensitiveMacros:
+  - STRINGIZE
+  - PP_STRINGIZE
+  - BOOST_PP_STRINGIZE
+---
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,75 @@
+name: test
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+
+jobs:
+  luacheck:
+    runs-on: ubuntu-latest
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    -
+      name: Setup Lua
+      uses: mah0x211/setup-lua@v1
+    -
+      name: Install Tools
+      run: luarocks install luacheck
+    -
+      name: Run luacheck
+      run: |
+        luacheck .
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        lua-version:
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
+    steps:
+    -
+      name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+    -
+      name: Setup Lua ${{ matrix.lua-version }}
+      uses: mah0x211/setup-lua@v1
+      with:
+        versions: ${{ matrix.lua-version }}
+    -
+      name: Install
+      run: |
+        luarocks make BASE32_COVERAGE=1
+    -
+      name: Install Tools
+      run: |
+        sudo apt install lcov -y
+        luarocks install assert
+        luarocks install string-random
+    -
+      name: Run Test
+      run: |
+        lua ./test/base32_test.lua
+    -
+      name: Generate coverage reports
+      run: |
+        sh ./covgen.sh
+    -
+      name: Upload c coverage to Codecov
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        files: ./coverage/lcov.info
+        flags: unittests

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+coverage/
+*.gcda
+*.gcno
+*.gcov

--- a/.lua-format
+++ b/.lua-format
@@ -1,0 +1,9 @@
+break_after_table_lb: true
+break_before_table_rb: false
+break_before_functioncall_rp: true
+break_before_functiondef_rp: true
+chop_down_table: true
+extra_sep_at_table_end: true
+keep_simple_control_block_one_line: false
+keep_simple_function_one_line: false
+column_table_limit: 1

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,5 @@
+std = 'max'
+include_files = {
+    "test/**/*_test.lua",
+}
+ignore = {}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+TARGET=base32.$(LIB_EXTENSION)
+SRCS=$(wildcard $(SRCDIR)/*.c)
+OBJS=$(SRCS:.c=.o)
+GCDAS=$(OBJS:.o=.gcda)
+INSTALL?=install
+
+ifdef BASE32_COVERAGE
+COVFLAGS=--coverage
+endif
+
+.PHONY: all install
+
+all: $(TARGET)
+
+%.o: %.c
+	$(CC) $(CFLAGS) $(WARNINGS) $(COVFLAGS) $(CPPFLAGS) -o $@ -c $<
+
+$(TARGET): $(OBJS)
+	$(CC) -o $@ $^ $(LDFLAGS) $(LIBS) $(PLATFORM_LDFLAGS) $(COVFLAGS)
+
+install:
+	$(INSTALL) -d $(INST_LIBDIR)
+	$(INSTALL) $(TARGET) $(INST_LIBDIR)
+	rm -f $(OBJS) $(TARGET) $(GCDAS)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,177 @@
 # lua-base32
+
+[![test](https://github.com/mah0x211/lua-base32/actions/workflows/test.yml/badge.svg)](https://github.com/mah0x211/lua-base32/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/mah0x211/lua-base32/branch/master/graph/badge.svg)](https://codecov.io/gh/mah0x211/lua-base32)
+
+Base32 encoding/decoding module for Lua with support for both RFC 4648 and Crockford's Base32 formats.
+
+## Installation
+
+```bash
+luarocks install base32
+```
+
+## Error Handling
+
+the following functions return an `error` object created by https://github.com/mah0x211/lua-errno module.
+
+
+## str = base32.encode(data [, format])
+
+Encodes a string using Base32 encoding.
+
+**Parameters:**
+
+- `data:string`: The data to encode.
+- `format:string`: The encoding format
+    - `"rfc"`: RFC 4648 Base32 (default)
+    - `"crockford"`: Crockford's Base32 encoding
+
+**Returns:**
+
+- `str:string`: The Base32 encoded string
+
+**Example:**
+
+```lua
+local base32 = require("base32")
+
+-- RFC 4648 Base32 (default)
+print(base32.encode("foobar")) -- "MZXW6YTBOI======"
+
+-- Crockford's Base32
+print(base32.encode("foobar", "crockford")) -- "CSQPYRK1E8"
+```
+
+## str, err = base32.decode(data [, format])
+
+Decodes a Base32 encoded string.
+
+**Parameters:**
+
+- `data:string`: The Base32 encoded string to decode
+- `format:string`: The decoding format
+    - `"rfc"`: RFC 4648 Base32 (default)
+    - `"crockford"`: Crockford's Base32 encoding
+
+**Returns:**
+
+- `str:string`: The decoded data on success, or `nil` on failure
+- `err:any`: nil and an error object on failure
+
+**Example:**
+
+```lua
+local base32 = require("base32")
+
+-- RFC 4648 Base32 (default)
+print(base32.decode("MZXW6YTBOI======")) -- "foobar"
+
+-- Crockford's Base32
+print(base32.decode("CSQPYRK1E8", "crockford")) -- "foobar"
+
+-- Error handling
+local res, err = base32.decode("INVALID!")
+if not res then
+    print("Decode error:", err)
+    -- Decode error:	./test.lua:10: in main chunk: [EILSEQ:92][base32.decode] Illegal byte sequence (Illegal character in Base32 string: '!' (0x21) at position 8)
+end
+
+```
+
+## Encoding Formats
+
+### RFC 4648 Base32
+
+The standard Base32 encoding as defined in [RFC 4648](https://datatracker.ietf.org/doc/html/rfc4648#section-6).
+
+**Characteristics:**
+
+- Alphabet: `A-Z`, `2-7`
+- Padding: Uses `=` for padding to make output length a multiple of 8
+- Case-insensitive decoding
+- Valid padding lengths: 0, 1, 3, 4, or 6 characters
+
+**Example:**
+
+```lua
+local base32 = require("base32")
+
+-- Encoding
+base32.encode("")        -- ""
+base32.encode("f")       -- "MY======"
+base32.encode("fo")      -- "MZXQ===="
+base32.encode("foo")     -- "MZXW6==="
+base32.encode("foob")    -- "MZXW6YQ="
+base32.encode("fooba")   -- "MZXW6YTB"
+base32.encode("foobar")  -- "MZXW6YTBOI======"
+
+-- Decoding (case-insensitive)
+base32.decode("MZXW6YTBOI======")  -- "foobar"
+base32.decode("mzxw6ytboi======")  -- "foobar"
+```
+
+
+### Crockford's Base32
+
+An alternative Base32 encoding designed to be more human-friendly, as described at [crockford.com/base32.html](https://www.crockford.com/base32.html).
+
+**Characteristics:**
+
+- Alphabet: `0-9`, `A-H`, `J-K`, `M-N`, `P-T`, `V-Z` (excludes `I`, `L`, `O`, `U`)
+- No padding characters
+- Case-insensitive decoding
+- Special character mappings:
+  - `I` and `L` decode as `1`
+  - `O` decodes as `0`
+  - Hyphens (`-`) are ignored for readability
+  - `U` is invalid
+
+**Example:**
+
+```lua
+local base32 = require("base32")
+
+-- Encoding
+print(base32.encode("foobar", "crockford")) -- "CSQPYRK1E8"
+
+-- Decoding with special mappings
+print(base32.decode("CSQPYRK1E8", "crockford")) -- "foobar"
+print(base32.decode("CSQPYRKIE8", "crockford")) -- "foobar" (I→1)
+print(base32.decode("CSQPYRKLE8", "crockford")) -- "foobar" (L→1)
+print(base32.decode("CS-QP-YRK1E8", "crockford")) -- "foobar" (hyphens ignored)
+```
+
+## Error Handling
+
+The decode function returns `nil` and an error object when decoding fails:
+
+```lua
+local base32 = require("base32")
+
+-- Invalid character
+local result, err = base32.decode("MZXW6YT8") -- '8' is invalid in RFC 4648
+if not result then
+    print(err)
+    -- ./test.lua:4: in main chunk: [EILSEQ:92][base32.decode] Illegal byte sequence (Illegal character in Base32 string: '8' (0x38) at position 8)
+end
+
+-- Invalid padding
+result, err = base32.decode("MZXW6Y==") -- 2 padding chars is invalid
+if not result then
+    print(err)
+    -- ./test.lua:10: in main chunk: [EINVAL:22][base32.decode] Invalid argument (RFC 4648 Base32 padding length must be 0, 1, 3, 4, or 6)
+end
+
+-- Invalid length for RFC format
+result, err = base32.decode("MZXW6") -- Must be multiple of 8
+if not result then
+    print(err)
+    -- ./test.lua:16: in main chunk: [EINVAL:22][base32.decode] Invalid argument (RFC 4648 Base32 requires input length to be a multiple of 8)
+end
+```
+
+## License
+
+MIT License
+

--- a/covgen.sh
+++ b/covgen.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env sh
+
+set -ex
+
+LCOV_IGNORE_ERRORS="--ignore-errors unused"
+
+mkdir -p ./coverage
+lcov -c -d ./src -o coverage/lcov.info.all
+lcov -r coverage/lcov.info.all \
+    '*/include/*' \
+    $LCOV_IGNORE_ERRORS \
+    -o coverage/lcov.info
+# genhtml -o coverage/html coverage/lcov.info

--- a/rockspecs/base32-dev-1.rockspec
+++ b/rockspecs/base32-dev-1.rockspec
@@ -1,0 +1,32 @@
+package = "base32"
+version = "dev-1"
+source = {
+    url = "git+https://github.com/mah0x211/lua-base32.git",
+}
+description = {
+    summary = "base32 encode/decode module",
+    homepage = "https://github.com/mah0x211/lua-base32",
+    license = "MIT/X11",
+    maintainer = "Masatoshi Fukunaga",
+}
+dependencies = {
+    "lua >= 5.1",
+    "errno >= 0.5.0",
+}
+build = {
+    type = "make",
+    build_variables = {
+        SRCDIR = "src",
+        CFLAGS = "$(CFLAGS)",
+        WARNINGS = "-Wall -Wno-trigraphs -Wmissing-field-initializers -Wreturn-type -Wmissing-braces -Wparentheses -Wno-switch -Wunused-function -Wunused-label -Wunused-parameter -Wunused-variable -Wunused-value -Wuninitialized -Wunknown-pragmas -Wshadow -Wsign-compare",
+        CPPFLAGS = "-I$(LUA_INCDIR)",
+        LDFLAGS = "$(LIBFLAG)",
+        LIB_EXTENSION = "$(LIB_EXTENSION)",
+        BASE32_COVERAGE = "$(BASE32_COVERAGE)",
+    },
+    install_variables = {
+        SRCDIR = "src",
+        INST_LIBDIR = "$(LIBDIR)",
+        LIB_EXTENSION = "$(LIB_EXTENSION)",
+    },
+}

--- a/src/base32.c
+++ b/src/base32.c
@@ -1,0 +1,340 @@
+/**
+ *  Copyright 2025 Masatoshi Fukunaga. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+
+#include "lua_errno.h"
+#include <lauxlib.h>
+#include <lua.h>
+// include system headers
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * @brief Check if the argument at index `arg` is a string and return its value.
+ *
+ * @param L Lua state
+ * @param arg Argument index
+ * @param len Pointer to store the length of the string
+ * @return const char* Pointer to the string value
+ */
+static inline const uint8_t *checklbytes(lua_State *L, int arg, size_t *len)
+{
+    luaL_checktype(L, arg, LUA_TSTRING);
+    return (const uint8_t *)lua_tolstring(L, arg, len);
+}
+
+// RFC 4648 Base32 Decoding table
+// https://datatracker.ietf.org/doc/html/rfc4648#section-6
+static const uint8_t RFC_DECODE_TABLE[256] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF,
+
+    // 2-7
+    26, 27, 28, 29, 30, 31,
+
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+    // A-Z
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25,
+
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+    // a-z
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25,
+
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF};
+
+// Crockford's Base32 Decoding table (0xFF means invalid character)
+static const uint8_t CROCKFORD_DECODE_TABLE[256] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+    // 0-9
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+    // A-Z (I=1, L=1, O=0, U=0xFF)
+    10, 11, 12, 13, 14, 15, 16, 17, 1, 18, 19, 1, 20, 21, 0, 22, 23, 24, 25, 26,
+    0xFF, 27, 28, 29, 30, 31,
+
+    //
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+
+    // a-z (i=1, l=1, o=0, u=0xFF)
+    10, 11, 12, 13, 14, 15, 16, 17, 1, 18, 19, 1, 20, 21, 0, 22, 23, 24, 25, 26,
+    0xFF, 27, 28, 29, 30, 31,
+
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, -1};
+
+static int decode_lua(lua_State *L)
+{
+    size_t len               = 0;
+    const uint8_t *src       = checklbytes(L, 1, &len);
+    const char *const opts[] = {"rfc", "crockford", NULL};
+    int opt                  = luaL_checkoption(L, 2, "rfc", opts);
+    const uint8_t *tbl       = NULL;
+    uint64_t acc             = 0;
+    int nbits                = 0;
+    luaL_Buffer b            = {0};
+
+    // If the input string is empty, return empty string
+    if (len == 0) {
+        lua_pushliteral(L, "");
+        return 1;
+    }
+
+    // reset errno for error handling
+    errno = 0;
+
+    // select lookup table based on format
+    switch (opt) {
+    case 0: { // RFC 4648 Base32
+        tbl = RFC_DECODE_TABLE;
+        // RFC 4648 Base32 requires input length to be a multiple of 8
+        if (len % 8 != 0) {
+            lua_pushnil(L);
+            errno = EINVAL;
+            lua_errno_new_with_message(
+                L, errno, "base32.decode",
+                "RFC 4648 Base32 requires input length to be a multiple of 8");
+            return 2;
+        }
+
+        // remove padding characters
+        int npad      = 0;
+        uint8_t *tail = (uint8_t *)src + len;
+        for (; tail > src && tail[-1] == '='; --tail) {
+            len--;
+            npad++;
+            if (npad > 6) {
+                // RFC 4648 Base32 allows at most 6 padding characters
+                lua_pushnil(L);
+                errno = EINVAL;
+                lua_errno_new_with_message(
+                    L, errno, "base32.decode",
+                    "RFC 4648 Base32 padding length must be 0, 1, 3, 4, or 6");
+                return 2;
+            }
+        }
+        // number of padding characters must be 0, 1, 3, 4, or 6
+        if (npad != 0 && npad != 1 && npad != 3 && npad != 4 && npad != 6) {
+            lua_pushnil(L);
+            errno = EINVAL;
+            lua_errno_new_with_message(
+                L, errno, "base32.decode",
+                "RFC 4648 Base32 padding length must be 0, 1, 3, 4, or 6");
+            return 2;
+        }
+    } break;
+
+    case 1: // crockford
+        tbl = CROCKFORD_DECODE_TABLE;
+        break;
+    }
+
+    // Calculate maximum output size (5 bits per character -> 8 bits per
+    // byte) size_t dstlen      = (len * 5 + 7) / 8;
+    luaL_buffinit(L, &b);
+
+    for (size_t i = 0; i < len; i++) {
+        uint8_t c  = src[i];
+        uint8_t dc = tbl[c];
+
+        // In Crockford's Base32, '-' is allowed for readability
+        if (c == '-' && tbl == CROCKFORD_DECODE_TABLE) {
+            continue;
+        }
+
+        // Check if character is valid
+        if (dc > 31) {
+            char errmsg[256] = {0};
+            snprintf(errmsg, sizeof(errmsg),
+                     "Illegal character in Base32 string: '%c' (0x%02X) at "
+                     "position %d",
+                     c, c, (int)(i + 1));
+            lua_pushnil(L);
+            errno = EILSEQ;
+            lua_errno_new_with_message(L, errno, "base32.decode", errmsg);
+            return 2;
+        }
+
+        // Add 5 bits to buffer
+        acc = (acc << 5) | dc;
+        nbits += 5;
+
+        // Extract 5 bytes when we have 40 bits
+        if (nbits >= 40) {
+            // Extract 5 bytes (40 bits)
+            char buf[5] = {
+                (acc >> 32) & 0xFF, (acc >> 24) & 0xFF, (acc >> 16) & 0xFF,
+                (acc >> 8) & 0xFF,  acc & 0xFF,
+            };
+            luaL_addlstring(&b, buf, 5);
+            acc >>= 40;
+            nbits -= 40;
+        }
+    }
+
+    // Handle remaining bits (less than 40 bits)
+    while (nbits >= 8) {
+        nbits -= 8;
+        luaL_addchar(&b, (acc >> nbits) & 0xFF);
+    }
+
+    // Push result as Lua string
+    luaL_pushresult(&b);
+    return 1;
+}
+
+// RFC 4648 Base32 encoding/decoding
+// https://datatracker.ietf.org/doc/html/rfc4648#section-6
+static const char RFC_ALPHABET[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+// Crockford's Base32 alphabet (excluding I, L, O, U)
+static const char CROCKFORD_ALPHABET[] = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+static int encode_lua(lua_State *L)
+{
+    size_t len               = 0;
+    const uint8_t *src       = checklbytes(L, 1, &len);
+    const uint8_t *head      = src;
+    const uint8_t *tail      = head + len;
+    const char *const opts[] = {"rfc", "crockford", NULL};
+    int opt                  = luaL_checkoption(L, 2, "rfc", opts);
+    const char *tbl          = NULL;
+    size_t outlen            = 0;
+    luaL_Buffer b            = {0};
+
+    // If the input string is empty, return empty string
+    if (len == 0) {
+        lua_pushliteral(L, "");
+        return 1;
+    }
+
+    // select lookup table based on option
+    switch (opt) {
+    case 0: // RFC 4648 Base32
+        tbl = RFC_ALPHABET;
+        break;
+    case 1: // crockford
+        tbl = CROCKFORD_ALPHABET;
+        break;
+    }
+
+    luaL_buffinit(L, &b);
+
+    // Process 5 bytes at a time (40 bits -> 8 characters)
+    while ((tail - head) >= 5) {
+        // Load 5 bytes (40 bits)
+        uint64_t acc = ((uint64_t)head[0] << 32) | ((uint64_t)head[1] << 24) |
+                       ((uint64_t)head[2] << 16) | ((uint64_t)head[3] << 8) |
+                       (uint64_t)head[4];
+        // Extract 8 characters (5 bits each)
+        char buf[8] = {tbl[(acc >> 35) & 0x1F], tbl[(acc >> 30) & 0x1F],
+                       tbl[(acc >> 25) & 0x1F], tbl[(acc >> 20) & 0x1F],
+                       tbl[(acc >> 15) & 0x1F], tbl[(acc >> 10) & 0x1F],
+                       tbl[(acc >> 5) & 0x1F],  tbl[acc & 0x1F]};
+        luaL_addlstring(&b, buf, 8);
+        outlen += 8; // Increment output length by 8 characters
+        head += 5;   // Move source pointer forward by 5 bytes
+    }
+
+    // Handle remaining bytes (1-4 bytes)
+    if (head < tail) {
+        uint32_t acc = 0;
+        int nbits    = 0;
+
+        // Load remaining bytes into accumulator
+        while (head < tail) {
+            acc = (acc << 8) | *head++;
+            nbits += 8;
+        }
+        // Extract all complete 5-bit groups
+        while (nbits >= 5) {
+            nbits -= 5;
+            luaL_addchar(&b, tbl[(acc >> nbits) & 0x1F]);
+            outlen++;
+        }
+        // Handle remaining bits (if any)
+        if (nbits > 0) {
+            luaL_addchar(&b, tbl[(acc << (5 - nbits)) & 0x1F]);
+            outlen++;
+        }
+    }
+
+    // Add padding for RFC Base32 format
+    if (tbl == RFC_ALPHABET && outlen % 8 != 0) {
+        // Calculate current length from the data we've written
+        static const char PAD[8] = "========";
+        size_t padding_len       = 8 - (outlen % 8);
+        // Add padding characters
+        luaL_addlstring(&b, PAD, padding_len);
+    }
+
+    // Null terminate and push result
+    luaL_pushresult(&b);
+    return 1;
+}
+
+LUALIB_API int luaopen_base32(lua_State *L)
+{
+    // Load errno library for error handling
+    lua_errno_loadlib(L);
+    // Export the base32 functions
+    lua_createtable(L, 0, 2);
+    lua_pushcfunction(L, encode_lua);
+    lua_setfield(L, -2, "encode");
+    lua_pushcfunction(L, decode_lua);
+    lua_setfield(L, -2, "decode");
+    return 1;
+}

--- a/test/base32_test.lua
+++ b/test/base32_test.lua
@@ -1,0 +1,431 @@
+#!/usr/bin/env lua
+
+local base32 = require("base32")
+
+-- Test framework
+local tests = {}
+local failed = 0
+local passed = 0
+
+local function test(name, fn)
+    tests[#tests + 1] = {
+        name = name,
+        fn = fn,
+    }
+end
+
+local function run_tests()
+    print("Running base32 tests...")
+    for _, t in ipairs(tests) do
+        local ok, err = pcall(t.fn)
+        if ok then
+            passed = passed + 1
+            print(string.format("✓ %s", t.name))
+        else
+            failed = failed + 1
+            print(string.format("✗ %s: %s", t.name, err))
+        end
+    end
+    print(string.format("\nPassed: %d, Failed: %d", passed, failed))
+    os.exit(failed > 0 and 1 or 0)
+end
+
+-- Helper function to compare values
+local function assert_eq(got, expected, msg)
+    if got ~= expected then
+        error(string.format("%s: expected %q, got %q",
+                            msg or "assertion failed", expected, got))
+    end
+end
+
+-- RFC 4648 Base32 Tests
+
+test("test_rfc_test_vectors", function()
+    -- Test all RFC 4648 Test Vectors
+    local test_vectors = {
+        {
+            "",
+            "",
+        },
+        {
+            "f",
+            "MY======",
+        },
+        {
+            "fo",
+            "MZXQ====",
+        },
+        {
+            "foo",
+            "MZXW6===",
+        },
+        {
+            "foob",
+            "MZXW6YQ=",
+        },
+        {
+            "fooba",
+            "MZXW6YTB",
+        },
+        {
+            "foobar",
+            "MZXW6YTBOI======",
+        },
+    }
+
+    for _, vector in ipairs(test_vectors) do
+        local input, expected = vector[1], vector[2]
+
+        -- Test encoding
+        local encoded = base32.encode(input)
+        assert_eq(encoded, expected,
+                  string.format("encode RFC vector: %q", input))
+
+        -- Test decoding
+        local decoded = base32.decode(expected)
+        assert_eq(decoded, input,
+                  string.format("decode RFC vector: %q", expected))
+    end
+end)
+
+test("test_rfc_padding_validation", function()
+    -- Test valid padding patterns (0, 1, 3, 4, 6)
+    local valid_padding = {
+        {
+            "MZXW6YTB",
+            "fooba",
+            0,
+        }, -- 0 padding
+        {
+            "MZXW6YQ=",
+            "foob",
+            1,
+        }, -- 1 padding
+        {
+            "MZXW6===",
+            "foo",
+            3,
+        }, -- 3 padding
+        {
+            "MZXQ====",
+            "fo",
+            4,
+        }, -- 4 padding
+        {
+            "MY======",
+            "f",
+            6,
+        }, -- 6 padding
+    }
+
+    for _, case in ipairs(valid_padding) do
+        local encoded, expected, pad_count = case[1], case[2], case[3]
+        local result = base32.decode(encoded)
+        assert_eq(result, expected, string.format("valid %d padding", pad_count))
+    end
+
+    -- Test invalid padding patterns (2, 5, 7)
+    local invalid_padding = {
+        {
+            "MZXW6Y==",
+            2,
+        }, -- 2 padding
+        {
+            "MZX=====",
+            5,
+        }, -- 5 padding
+        {
+            "M=======",
+            7,
+        }, -- 7 padding
+    }
+
+    for _, case in ipairs(invalid_padding) do
+        local encoded, pad_count = case[1], case[2]
+        local res, err = base32.decode(encoded)
+        assert(not res, string.format("should reject %d padding", pad_count))
+        assert(tostring(err):match("padding length must be 0, 1, 3, 4, or 6"),
+               string.format(
+                   "error should mention padding length must be 0, 1, 3, 4, or 6",
+                   pad_count))
+    end
+end)
+
+test("test_rfc_character_validation", function()
+    -- Test case insensitive decoding
+    local test_string = "MZXW6YTBOI======"
+    local upper = base32.decode(test_string)
+    local lower = base32.decode(test_string:lower())
+    local mixed = base32.decode("MzXw6YtBoI======")
+
+    assert_eq(upper, "foobar", "uppercase decode")
+    assert_eq(lower, "foobar", "lowercase decode")
+    assert_eq(mixed, "foobar", "mixed case decode")
+
+    -- Test invalid characters for RFC 4648
+    local invalid_chars = {
+        "0",
+        "1",
+        "8",
+        "9",
+        "!",
+    }
+    for _, char in ipairs(invalid_chars) do
+        local invalid_string = "MZXW6YT" .. char
+        local res, err = base32.decode(invalid_string)
+        assert(not res,
+               string.format("should reject invalid character '%s'", char))
+        assert(tostring(err):match("Illegal character in Base32 string"))
+    end
+end)
+
+test("test_rfc_length_validation", function()
+    -- RFC requires input length to be multiple of 8
+    local invalid_lengths = {
+        "MZXW6YT",
+        "MZXW6",
+        "M",
+    }
+    for _, invalid in ipairs(invalid_lengths) do
+        local res, err = base32.decode(invalid)
+        assert(not res,
+               string.format("should reject length %d", string.len(invalid)))
+        assert(tostring(err):match("input length to be a multiple of 8"),
+               "error should mention invalid length")
+    end
+end)
+
+test("test_rfc_binary_data", function()
+    -- Test binary data handling
+    local binary = string.char(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    local encoded = base32.encode(binary)
+
+    -- Verify it produces valid Base32
+    assert(encoded:match("^[A-Z2-7=]+$"),
+           "encoded binary should be valid Base32")
+
+    -- Test round trip
+    local decoded = base32.decode(encoded)
+    assert_eq(decoded, binary, "binary data round trip")
+
+    -- Test all byte values
+    local all_bytes = ""
+    for i = 0, 255 do
+        all_bytes = all_bytes .. string.char(i)
+    end
+    encoded = base32.encode(all_bytes)
+    decoded = base32.decode(encoded)
+    assert_eq(decoded, all_bytes, "all byte values round trip")
+end)
+
+test("test_rfc_byte_length_patterns", function()
+    -- Test different input lengths to verify correct padding
+    local length_tests = {
+        {
+            "a",
+            8,
+            6,
+        }, -- 1 byte -> 8 chars with 6 padding
+        {
+            "ab",
+            8,
+            4,
+        }, -- 2 bytes -> 8 chars with 4 padding
+        {
+            "abc",
+            8,
+            3,
+        }, -- 3 bytes -> 8 chars with 3 padding
+        {
+            "abcd",
+            8,
+            1,
+        }, -- 4 bytes -> 8 chars with 1 padding
+        {
+            "abcde",
+            8,
+            0,
+        }, -- 5 bytes -> 8 chars with 0 padding
+    }
+
+    for _, test_case in ipairs(length_tests) do
+        local input, expected_len, expected_padding = test_case[1],
+                                                      test_case[2], test_case[3]
+        local encoded = base32.encode(input, "rfc")
+
+        assert_eq(string.len(encoded), expected_len,
+                  string.format("%d bytes should encode to %d characters",
+                                string.len(input), expected_len))
+
+        local padding_count = string.len(encoded) -
+                                  string.len(encoded:gsub("=", ""))
+        assert_eq(padding_count, expected_padding,
+                  string.format("%d bytes should have %d padding chars",
+                                string.len(input), expected_padding))
+
+        -- Test round trip
+        local decoded = base32.decode(encoded)
+        assert_eq(decoded, input,
+                  string.format("round trip for %d bytes", string.len(input)))
+    end
+end)
+
+-- Crockford Base32 Tests
+
+test("test_crockford_basic_functionality", function()
+    -- Test basic encoding/decoding
+    assert_eq(base32.encode("", "crockford"), "", "empty string encoding")
+    assert_eq(base32.decode("", "crockford"), "", "empty string decoding")
+
+    -- Test no padding
+    local result = base32.encode("f", "crockford")
+    assert(not result:match("="), "Crockford Base32 should not use padding")
+    assert_eq(result, "CR", "single char encoding")
+
+    -- Test known values
+    assert_eq(base32.encode("foobar", "crockford"), "CSQPYRK1E8",
+              "foobar encoding")
+    assert_eq(base32.decode("CSQPYRK1E8", "crockford"), "foobar",
+              "foobar decoding")
+end)
+
+test("test_crockford_special_characters", function()
+    -- Test case insensitive
+    local test_cases = {
+        {
+            "CSQPYRK1E8",
+            "uppercase",
+        },
+        {
+            "csqpyrk1e8",
+            "lowercase",
+        },
+        {
+            "CsQpYrK1e8",
+            "mixed case",
+        },
+    }
+
+    for _, case in ipairs(test_cases) do
+        local encoded, desc = case[1], case[2]
+        local result = base32.decode(encoded, "crockford")
+        assert_eq(result, "foobar", desc .. " decode")
+    end
+
+    -- Test hyphen handling
+    local with_hyphens = base32.decode("CS-QP-YR-K1-E8", "crockford")
+    local multiple_hyphens = base32.decode("CS--QP---YRK1E8", "crockford")
+    assert_eq(with_hyphens, "foobar", "decode with hyphens")
+    assert_eq(multiple_hyphens, "foobar", "decode with multiple hyphens")
+
+    -- Test I/L -> 1 mapping
+    local with_i = base32.decode("CSQPYRKIE8", "crockford")
+    local with_l = base32.decode("CSQPYRKLE8", "crockford")
+    assert_eq(with_i, "foobar", "I maps to 1")
+    assert_eq(with_l, "foobar", "L maps to 1")
+
+    -- Test O -> 0 mapping
+    local with_o = base32.decode("OSQPYRK1E8", "crockford")
+    local with_zero = base32.decode("0SQPYRK1E8", "crockford")
+    assert_eq(with_o, with_zero, "O maps to 0")
+end)
+
+test("test_crockford_invalid_characters", function()
+    -- Test invalid characters
+    local invalid_chars = {
+        "U",
+        "!",
+    }
+    for _, char in ipairs(invalid_chars) do
+        local invalid_string = "CSQPYRK" .. char .. "E8"
+        local res, err = base32.decode(invalid_string, "crockford")
+        assert(not res,
+               string.format("should reject invalid character '%s'", char))
+        assert(tostring(err):match("Illegal character.*'" .. char),
+               string.format("error should mention invalid character '%s'", char))
+    end
+end)
+
+test("test_crockford_binary_data", function()
+    -- Test binary data round trip
+    local binary = string.char(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
+    local encoded = base32.encode(binary, "crockford")
+    local decoded = base32.decode(encoded, "crockford")
+    assert_eq(decoded, binary, "Crockford binary data round trip")
+
+    -- Test longer string
+    local long_str = string.rep("0123456789", 100)
+    encoded = base32.encode(long_str, "crockford")
+    decoded = base32.decode(encoded, "crockford")
+    assert_eq(decoded, long_str, "long string Crockford round trip")
+end)
+
+-- General functionality tests
+
+test("test_format_handling", function()
+    -- Test default format
+    local rfc_explicit = base32.encode("test", "rfc")
+    local rfc_default = base32.encode("test")
+    assert_eq(rfc_default, rfc_explicit, "default format should be RFC")
+
+    local decoded_default = base32.decode(rfc_explicit)
+    local decoded_explicit = base32.decode(rfc_explicit, "rfc")
+    assert_eq(decoded_default, decoded_explicit,
+              "default decode format should be RFC")
+
+    -- Test invalid format
+    local invalid_formats = {
+        "invalid",
+        "base64",
+        "hex",
+    }
+    for _, format in ipairs(invalid_formats) do
+        local ok_encode, err_encode = pcall(base32.encode, "test", format)
+        local ok_decode, err_decode = pcall(base32.decode, "TEST", format)
+
+        assert(not ok_encode, string.format(
+                   "should reject invalid encode format '%s'", format))
+        assert(not ok_decode, string.format(
+                   "should reject invalid decode format '%s'", format))
+        assert(err_encode:match("option") or err_encode:match("invalid"),
+               "encode error should mention invalid option")
+        assert(err_decode:match("option") or err_decode:match("invalid"),
+               "decode error should mention invalid option")
+    end
+end)
+
+test("test_argument_validation", function()
+    -- Test non-string argument cannot be decoded
+    local ok, err = pcall(base32.decode, 123)
+    assert(not ok, "should fail with non-string decode argument")
+    assert(err:match("string expected, got number"),
+           "error should mention string expected for decode")
+end)
+
+test("test_comprehensive_round_trips", function()
+    -- Test various string lengths
+    local test_strings = {
+        "",
+        "a",
+        "hello",
+        "Hello, World!",
+        string.rep("abcdefghijklmnopqrstuvwxyz", 10),
+    }
+
+    for _, original in ipairs(test_strings) do
+        -- RFC round trip
+        local rfc_encoded = base32.encode(original, "rfc")
+        local rfc_decoded = base32.decode(rfc_encoded, "rfc")
+        assert_eq(rfc_decoded, original,
+                  string.format("RFC round trip for: %q", original))
+
+        -- Crockford round trip
+        local crockford_encoded = base32.encode(original, "crockford")
+        local crockford_decoded = base32.decode(crockford_encoded, "crockford")
+        assert_eq(crockford_decoded, original,
+                  string.format("Crockford round trip for: %q", original))
+    end
+end)
+
+-- Run all tests
+run_tests()


### PR DESCRIPTION
This pull request introduces a comprehensive set of changes aimed at implementing a Base32 encoding/decoding module, setting up code formatting standards, and configuring CI workflows for testing and coverage reporting. Below is a summary of the most significant changes grouped by theme:

### Base32 Module Implementation:
- **`src/base32.c`:** Added Base32 encoding and decoding functionality, supporting both RFC 4648 and Crockford formats. Includes error handling, padding management, and lookup tables for efficient encoding/decoding.

### Build and Installation:
- **`Makefile`:** Added build rules for compiling the Base32 module, with support for coverage flags and installation into specified directories.
- **`rockspecs/base32-dev-1.rockspec`:** Defined a LuaRocks specification for the Base32 module, including dependencies, build variables, and installation configurations.

### Code Formatting:
- **`.clang-format`:** Introduced C++ code formatting rules based on LLVM style, ensuring consistent structure and readability across the codebase.
- **`.lua-format`:** Added Lua code formatting rules to enforce consistent style, such as breaking tables and function calls across lines.

### Testing and CI Configuration:
- **`.github/workflows/test.yml`:** Set up GitHub Actions workflows for running tests and generating coverage reports. Includes Lua version matrix testing and integration with Codecov.
- **`covgen.sh`:** Script for generating coverage reports using lcov, filtering out irrelevant paths.

### Linting Configuration:
- **`.luacheckrc`:** Configured `luacheck` to lint Lua files, specifying standard rules and including test files for analysis.